### PR TITLE
BackgroundCells now have a background matching offrange days colors

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -13,6 +13,7 @@ import Selection, { getBoundsForNode, isEvent } from './Selection';
 class BackgroundCells extends React.Component {
 
   static propTypes = {
+    date: PropTypes.instanceOf(Date),
     cellWrapperComponent: elementType,
     container: PropTypes.func,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
@@ -54,12 +55,15 @@ class BackgroundCells extends React.Component {
   }
 
   render(){
+    let currentDate = this.props.date;
+    let isOffRange;
     let { range, cellWrapperComponent: Wrapper } = this.props;
     let { selecting, startIdx, endIdx } = this.state;
 
     return (
       <div className='rbc-row-bg'>
         {range.map((date, index) => {
+          isOffRange = dates.month(date) !== dates.month(currentDate)
           let selected =  selecting && index >= startIdx && index <= endIdx;
           return (
             <Wrapper
@@ -72,6 +76,7 @@ class BackgroundCells extends React.Component {
                 className={cn(
                   'rbc-day-bg',
                   selected && 'rbc-selected-cell',
+                  isOffRange && 'rbc-day-bg-offrange',
                   dates.isToday(date) && 'rbc-today',
                 )}
               />

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -15,6 +15,7 @@ import EventEndingRow from './EventEndingRow';
 let isSegmentInSlot = (seg, slot) => seg.left <= slot && seg.right >= slot;
 
 const propTypes = {
+  date: PropTypes.instanceOf(Date),
   events: PropTypes.array.isRequired,
   range: PropTypes.array.isRequired,
 
@@ -169,6 +170,7 @@ class DateContentRow extends React.Component {
     return (
       <div className={className}>
         <BackgroundCells
+          date={this.props.date}
           rtl={rtl}
           range={range}
           selectable={selectable}

--- a/src/Month.js
+++ b/src/Month.js
@@ -166,6 +166,7 @@ class MonthView extends React.Component {
 
     return (
       <DateContentRow
+        date={this.props.date}
         key={weekIdx}
         ref={weekIdx === 0 ? 'slotRow' : undefined}
         container={this.getContainer}

--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -40,6 +40,10 @@
   color: @out-of-range-color;
 }
 
+.rbc-day-bg-offrange {
+  background-color: @out-of-range-color;
+}
+
 .rbc-header {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/webpack/examples.config.js
+++ b/webpack/examples.config.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   stats: stats.minimal,
   devServer: {
-    port: 3000,
+    port: 3500,
     stats: stats.minimal,
   },
 


### PR DESCRIPTION
This adds the css class the `rbc-day-bg-offrange` class to days that do not belong into the current month and provides the possibility to set a custom background color and other css features.